### PR TITLE
Creating an AZSOutputStream from a blob by createOutputStream() causes a crash

### DIFF
--- a/Lib/Azure Storage Client Library/Azure Storage Client Library/AZSBlobOutputStream.m
+++ b/Lib/Azure Storage Client Library/Azure Storage Client Library/AZSBlobOutputStream.m
@@ -144,9 +144,8 @@ void AZSBlobOutputStreamRunLoopSourcePerformRoutine (void *info)
 
 -(instancetype)initWithAccessCondition:(AZSAccessCondition *)accessCondition requestOptions:(AZSBlobRequestOptions *)requestOptions operationContext:(AZSOperationContext *)operationContext
 {
-    // A designated initializer must make a super call to a designated initializer of the super class.
-    uint8_t temp;
-    self = [super initToBuffer:&temp capacity:0];
+    // A super call to a designated initializer of the super class leads to a crash in iOS 7 or 8.
+    self = [super init];
     if (self)
     {
         _isStreamOpen = NO;


### PR DESCRIPTION
in iOS 7 & 8
calling blobBlock.createOutputStream() causes an exception
'[AZSBlobOutputStream initToBuffer: capacity:]: unrecognized selector sent to instance 0x17dc4ae0'
in 
-(instancetype)initWithAccessCondition:(AZSAccessCondition *)accessCondition requestOptions:(AZSBlobRequestOptions *)requestOptions operationContext:(AZSOperationContext *)operationContext
on line
self = [super initToBuffer:&temp capacity:0];

Changing it with calling non-designated initializer [super init] fixes the thing.