### PR TITLE
Refactor +dateFormatterWithFormat: to use dispactch_once

### DIFF
--- a/Lib/Azure Storage Client Library/Azure Storage Client Library/AZSUtil.m
+++ b/Lib/Azure Storage Client Library/Azure Storage Client Library/AZSUtil.m
@@ -27,12 +27,14 @@
 +(NSDateFormatter *) dateFormatterWithFormat:(NSString *)format
 {
     static NSDateFormatter *df = nil;
-    if (!df) {
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         df = [[NSDateFormatter alloc] init];
         [df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:AZSCPosix]];
         [df setCalendar: [[NSCalendar alloc] initWithCalendarIdentifier:AZSGregorianCalendar]];
         [df setTimeZone:[NSTimeZone timeZoneWithName:AZSCUtc]];
-    }
+    });
     
     NSDateFormatter *dateFormat = [df copy];
     [dateFormat setDateFormat:format];


### PR DESCRIPTION
Using dispacth_once ensures that clients don't get random crashes resulting from multi-threading.